### PR TITLE
remove old type, when new type assigning.

### DIFF
--- a/src/perception_plugin_image_recognition.cpp
+++ b/src/perception_plugin_image_recognition.cpp
@@ -151,7 +151,11 @@ bool PerceptionPluginImageRecognition::srvClassify(ed_perception::Classify::Requ
         // Add the result to the response
         if (best_probability > req.unknown_probability)
         {
-          update_req_->setType(e->id(), label);
+            if (label != e->type() && !e->type().empty())
+            {
+                update_req_->removeType(e->id(), e->type());
+            }
+            update_req_->setType(e->id(), label); // no need to set type when label is equal to old type and not empty, but simpler code
         }
 
         // For some reason we defined the interface this way but this is much too much info for the client ..


### PR DESCRIPTION
fixes #25.
First time inspecting the cabinet in simulation
```
rosservice call /amigo/ed/simple_query "id: '94a87f4c8c6e45ce1f813ae510713fed'" 
entities: 
  - 
    id: 94a87f4c8c6e45ce1f813ae510713fed
    type: hairspray
    types: ['hairspray']
```
Inspect cabinet again. Random classifier returns other label.
```
rosservice call /amigo/ed/simple_query "id: '94a87f4c8c6e45ce1f813ae510713fed'" 
entities: 
  - 
    id: 94a87f4c8c6e45ce1f813ae510713fed
    type: ice_tea
    types: ['ice_tea']
```