### PR TITLE
Don't call image classification, if image is empty

### DIFF
--- a/src/perception_plugin_image_recognition.cpp
+++ b/src/perception_plugin_image_recognition.cpp
@@ -115,7 +115,7 @@ bool PerceptionPluginImageRecognition::srvClassify(ed_perception::Classify::Requ
                                 std::max(p_max.y - p_min.y - 5, 0));
         if (roi.area() == 0)
         {
-            ROS_ERROR("[ED Perception] Empty ImageMask, segmentation has probably gone wrong");
+            ROS_ERROR_STREAM("[ED Perception] Empty ImageMask of entity: '" << e->id()<< "', segmentation has probably gone wrong");
             continue;
         }
         cv::Mat cropped_image = image(roi);

--- a/src/perception_plugin_image_recognition.cpp
+++ b/src/perception_plugin_image_recognition.cpp
@@ -109,18 +109,22 @@ bool PerceptionPluginImageRecognition::srvClassify(ed_perception::Classify::Requ
             p_max.x = std::max(p_max.x, p.x);
             p_max.y = std::max(p_max.y, p.y);
         }
-
         cv::Rect roi = cv::Rect(std::min(p_min.x + 5, image.cols),
                                 std::min(p_min.y + 5, image.rows),
                                 std::max(p_max.x - p_min.x - 5, 0),
                                 std::max(p_max.y - p_min.y - 5, 0));
+        if (roi.area() == 0)
+        {
+            ROS_ERROR("[ED Perception] Empty ImageMask, segmentation has probably gone wrong");
+            continue;
+        }
         cv::Mat cropped_image = image(roi);
 
         // Convert it to the image request and call the service
         rgbd::convert(cropped_image, client_srv.request.image);
         if (!srv_client_.call(client_srv))
         {
-            ROS_ERROR("Service call failed");
+            ROS_ERROR("[ED Perception] Classification service call failed");
             continue;
         }
 


### PR DESCRIPTION
Let me add some explanation.
When a empty convexhull is created. The Imagemask is empty. This caused the crash, because of a incorrectly implementation of a custom iterator. See tue-robotics/ed#59. This is an ugly fix. Albert will make a good fix.
Now the roi can be empty, which causes the image to be sent to the image recognition to be empty, which causes an error in the image recognition. Therefore it shouldn't be sent if the image is empty.

Can only be tested by custom code in segmentation, which causes an empty convexhull.